### PR TITLE
[Explainer] Add alternative approach to extend `sendBeacon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,8 +409,6 @@ navigator.sendBeacon(url, data): bool
 
 To support the [requirements](#requirements) and to make the new API backward compatible, we propose the following shape:
 
-### New API
-
 ```ts
 navigator.sendBeacon(url, fetchOptions): PendingBeacon
 ```
@@ -418,7 +416,7 @@ navigator.sendBeacon(url, fetchOptions): PendingBeacon
 An optional dictionary argument `fetchOptions` can be passed in, which changes the return value from `bool` to `PendingBeacon` proposed in the above [PendingBeacon](#pendingbeacon) section. Some details to note:
 
 1.  The proposal would like to support both `POST` and `GET` requests. As the existing API only support `POST` beacons, passing in `fetchOptions` with `method: GET` should enable queuing `GET` beacons.
-2..  `fetchOptions` can only be a subset of the [Fetch API]'s [`RequestInit`] object:
+2.  `fetchOptions` can only be a subset of the [Fetch API]'s [`RequestInit`] object:
     1.  `method`: one of `GET` or `POST`.
     2.  `headers`: supports custom headers, which unblocks [#50].
     3.  `body`: `TypedArray`, `DataView` are not supported in the old API.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ even if the result goes out of scope,
 the beacon will still be sent (unless `deactivate()`-ed beforehand).
 
 The `url` parameter is a string that specifies the value of the `url` property.
-It works similar to the existing [`Navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does, except that it only supports https: scheme. The constructor throws a `TypeError` if getting an undefined or a null URL, or a URL of other scheme.
+It works similar to the existing [`navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does, except that it only supports https: scheme. The constructor throws a `TypeError` if getting an undefined or a null URL, or a URL of other scheme.
 
 The `options` parameter would be a dictionary that optionally allows specifying the following properties for the beacon:
 
@@ -197,7 +197,7 @@ After it is queued, even if the instance goes out of scope,
 the beacon will still be sent (unless `deactivate()`-ed beforehand).
 
 The `url` parameter is a string that specifies the value of the `url` property.
-It works similar to the existing [`Navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does, except that it only supports https: scheme. The constructor throws a `TypeError` if getting an undefined or a null URL, or a URL of other scheme.
+It works similar to the existing [`navigator.sendBeacon`][sendBeacon-api]’s `url` parameter does, except that it only supports https: scheme. The constructor throws a `TypeError` if getting an undefined or a null URL, or a URL of other scheme.
 
 The `options` parameter would be a dictionary that optionally allows specifying the following properties for the beacon:
 
@@ -479,7 +479,7 @@ The use case is for logging a total-so-far.
 The server would typically only pay attention to the latest value.
 
 [`XMLHttpRequest`]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
-[`navigator.sendBeacon`]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
+[sendbeacon-api]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
 [`fetch`]: https://developer.mozilla.org/en-US/docs/Web/API/fetch
 [sendBeacon-w3]: https://www.w3.org/TR/beacon/#sec-sendBeacon-method
 [ArrayBuffer-api]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer

--- a/README.md
+++ b/README.md
@@ -415,20 +415,20 @@ navigator.sendBeacon(url, fetchOptions): PendingBeacon
 
 An optional dictionary argument `fetchOptions` can be passed in, which changes the return value from `bool` to `PendingBeacon` proposed in the above [PendingBeacon](#pendingbeacon) section. Some details to note:
 
-1.  The proposal would like to support both `POST` and `GET` requests. As the existing API only support `POST` beacons, passing in `fetchOptions` with `method: GET` should enable queuing `GET` beacons.
-2.  `fetchOptions` can only be a subset of the [Fetch API]'s [`RequestInit`] object:
-    1.  `method`: one of `GET` or `POST`.
-    2.  `headers`: supports custom headers, which unblocks [#50].
-    3.  `body`: `TypedArray`, `DataView` are not supported in the old API.
-    4.  `credentials`: enforcing `same-origin` to be consistent.
-    5.  `cache`: not supported.
-    6.  `redirect`: enforcing `follow`.
-    7.  `referrer`: enforcing same-origin URL.
-    8.  `referrerPolicy`: enforcing `same-origin`.
-    9.  `keepalive`: enforcing `true`.
-    10. `integrity`: not supported.
-    11. `signal`: not supported. See below
-    12. `priority`: enforcing `auto`.
+1. The proposal would like to support both `POST` and `GET` requests. As the existing API only support `POST` beacons, passing in `fetchOptions` with `method: GET` should enable queuing `GET` beacons.
+2. `fetchOptions` can only be a subset of the [Fetch API]'s [`RequestInit`] object:
+   1. `method`: one of `GET` or `POST`.
+   2. `headers`: supports custom headers, which unblocks [#50].
+   3. `body`: `TypedArray`, `DataView` are not supported in the old API.
+   4. `credentials`: enforcing `same-origin` to be consistent.
+   5. `cache`: not supported.
+   6. `redirect`: enforcing `follow`.
+   7. `referrer`: enforcing same-origin URL.
+   8. `referrerPolicy`: enforcing `same-origin`.
+   9. `keepalive`: enforcing `true`.
+   10. `integrity`: not supported.
+   11. `signal`: not supported. See below
+   12. `priority`: enforcing `auto`.
 
 The reason why `signal` and `AbortController` is not desired is that the proposal would like to supports more than just aborting the requests, it also needs to check pending states and accumulate data. Supporting these requirements via the returned `PendingBeacon` object allows more flexibility.
 


### PR DESCRIPTION
This change summarizes the discussion from
https://github.com/WebKit/standards-positions/issues/85#issuecomment-1418381239 and also potentially unblocks the need to add custom headers in #50